### PR TITLE
Vault: Disable Agent Injector Admission Webhook controller

### DIFF
--- a/charts/vault/values.yml.gotmpl
+++ b/charts/vault/values.yml.gotmpl
@@ -41,12 +41,4 @@ server:
       memory: 200Mi
 
 injector:
-  image:
-    tag: 0.6.0
-  resources:
-    requests:
-      cpu: 10m
-      memory: 10Mi
-    limits:
-      cpu: 20m
-      memory: 20Mi
+  enabled: false


### PR DESCRIPTION
Because we're not actually using it.